### PR TITLE
Remove firefox/switch-en.ftl

### DIFF
--- a/en/firefox/switch-en.ftl
+++ b/en/firefox/switch-en.ftl
@@ -1,8 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-### TODO: Merge the content here with switch.ftl to expose new string.
-### This file is just a hack to avoid new content in the migration.
-
-switch-spread-the-word = Spread the word about Firefox and help your favorite people say goodbye to Chrome.


### PR DESCRIPTION
This file was removed in https://github.com/mozilla/bedrock/pull/8841, but during a migration of another file I noticed it crept back into the diff. I'm guessing it wasn't removed as part of the automation?