### PR TITLE
Deactivate fx/new/desktop with <80% translations

### DIFF
--- a/metadata/firefox/new/desktop.json
+++ b/metadata/firefox/new/desktop.json
@@ -46,7 +46,6 @@
     "pt-BR",
     "pt-PT",
     "rm",
-    "ro",
     "ru",
     "scn",
     "sco",

--- a/metadata/firefox/new/desktop.json
+++ b/metadata/firefox/new/desktop.json
@@ -60,7 +60,6 @@
     "th",
     "tr",
     "uk",
-    "ur",
     "vi",
     "zh-CN",
     "zh-TW"


### PR DESCRIPTION
Will fall back to fx/new/basic that still meets the activation threshold.

See https://github.com/mozilla/bedrock/issues/16010